### PR TITLE
Kube Cert Manager Authorizer

### DIFF
--- a/cmd/policy-admission/main.go
+++ b/cmd/policy-admission/main.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	// Version is the version of the service
-	Version = "v0.0.7"
+	Version = "v0.0.8"
 	// GitSHA is the git sha this was built off
 	GitSHA = "unknown"
 )

--- a/pkg/authorize/authorize.go
+++ b/pkg/authorize/authorize.go
@@ -23,6 +23,7 @@ import (
 	"github.com/UKHomeOffice/policy-admission/pkg/authorize/domains"
 	"github.com/UKHomeOffice/policy-admission/pkg/authorize/imagelist"
 	"github.com/UKHomeOffice/policy-admission/pkg/authorize/images"
+	"github.com/UKHomeOffice/policy-admission/pkg/authorize/kubecertmanager"
 	"github.com/UKHomeOffice/policy-admission/pkg/authorize/namespaces"
 	"github.com/UKHomeOffice/policy-admission/pkg/authorize/securitycontext"
 	"github.com/UKHomeOffice/policy-admission/pkg/authorize/services"
@@ -47,6 +48,8 @@ func newAuthorizer(name, path string) (api.Authorize, error) {
 		return images.NewFromFile(path)
 	case imagelist.Name:
 		return imagelist.NewFromFile(path)
+	case kubecertmanager.Name:
+		return kubecertmanager.NewFromFile(path)
 	case namespaces.Name:
 		return namespaces.NewFromFile(path)
 	case securitycontext.Name:

--- a/pkg/authorize/kubecertmanager/authorize.go
+++ b/pkg/authorize/kubecertmanager/authorize.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2017 Home Office All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubecertmanager
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/UKHomeOffice/policy-admission/pkg/api"
+	"github.com/UKHomeOffice/policy-admission/pkg/utils"
+
+	"github.com/patrickmn/go-cache"
+	extensions "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/kubernetes"
+)
+
+// resolver is purely wrapped for conveience of testing
+type resolver interface {
+	GetCNAME(string) (string, error)
+}
+
+type authorizer struct {
+	// config the configuration for the service
+	config *Config
+	// resolve is a dns resolver
+	resolve resolver
+}
+
+// Admit is responsible for authorizing the ingress for kube-cert-manager
+func (c *authorizer) Admit(client kubernetes.Interface, mcache *cache.Cache, object metav1.Object) field.ErrorList {
+	var errs field.ErrorList
+
+	ingress, ok := object.(*extensions.Ingress)
+	if !ok {
+		return append(errs, field.InternalError(field.NewPath("object"), errors.New("invalid object, expected Ingress")))
+	}
+
+	// @step: validate the ingress is ok for kube-cert-manager
+	return c.validateIngress(ingress)
+}
+
+// validateIngress checks the the image complys with policy
+func (c *authorizer) validateIngress(ingress *extensions.Ingress) field.ErrorList {
+	var errs field.ErrorList
+
+	label := "stable.k8s.psg.io/kcm.class"
+	class := "default"
+
+	// @check is this ingress has kube-cert-manager is enabled
+	if value, found := ingress.GetLabels()[label]; !found || value != class {
+		return errs
+	}
+
+	// @check if the domain is not within the internally hosts domain
+	if hosted := c.isHosted(ingress); hosted {
+		// @check we are not trying to use a http challenge
+
+		return errs
+	}
+
+	// @logic: else the domain it's requesting is outside of the internally hosted domain/s
+
+	label = "stable.k8s.psg.io/kcm.provider"
+	class = "http"
+	annontations := ingress.GetAnnotations()
+
+	// @check we have http challenge enabled
+	if value, found := annontations[label]; !found {
+		return append(errs, field.Invalid(field.NewPath("annotations").Key(label), value,
+			"one or more domains in the ingress are externally hosted, you must use a http challenge"))
+	} else if value != class {
+		return append(errs, field.Invalid(field.NewPath("annotations").Key(label), value,
+			fmt.Sprintf("invalid kube-cert-manager provider type: %s, expected: %s", value, class)))
+	}
+
+	// @check the nginx is external
+	label = "kubernetes.io/ingress.class"
+	class = "nginx-external"
+
+	if value, found := annontations[label]; !found {
+		return append(errs, field.Invalid(field.NewPath("annotations").Key(label), "",
+			"the ingress does not specify a nginx class in annotations"))
+	} else if value != class {
+		return append(errs, field.Invalid(field.NewPath("annotations").Key(label), value,
+			fmt.Sprintf("invalid kube-cert-manager provider, expected '%s' for a http challenge", class)))
+	}
+
+	// @check the dns for the hostnames are pointing to the cname of the external ingress controller
+	if pointed, err := c.isIngressPointed(ingress); err != nil {
+		return append(errs, field.InternalError(field.NewPath("dns validation"), fmt.Errorf("failed to check for dns validation: %s", err)))
+	} else {
+		errs = append(errs, pointed...)
+	}
+
+	return errs
+}
+
+// isHosted checks the domain is hosted by us
+func (c *authorizer) isHosted(ingress *extensions.Ingress) bool {
+	for _, x := range ingress.Spec.Rules {
+		for _, dns := range c.config.HostedDomains {
+			if strings.HasSuffix(x.Host, dns) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// isIngressPointed is responisble for checking the dns hostname is pointed to the external ingress
+func (c *authorizer) isIngressPointed(ingress *extensions.Ingress) (field.ErrorList, error) {
+	var errs field.ErrorList
+
+	for i, x := range ingress.Spec.Rules {
+		if cname, err := c.resolve.GetCNAME(x.Host); err != nil {
+			return errs, err
+		} else if cname != c.config.ExternalIngressHostname {
+			return append(errs, field.Invalid(field.NewPath("spec").Child("rules").Index(i).Child("host"), x.Host,
+				fmt.Sprintf("the hostname: %s is not pointed to the external ingress dns name %s", x.Host, c.config.ExternalIngressHostname))), nil
+		}
+	}
+
+	return errs, nil
+}
+
+// Name is the authorizer
+func (c *authorizer) Name() string {
+	return Name
+}
+
+// FilterOn returns the authorizer handle
+func (c *authorizer) FilterOn() api.Filter {
+	return api.Filter{
+		IgnoreNamespaces: c.config.IgnoreNamespaces,
+		Kind:             api.FilterIngresses,
+	}
+}
+
+// New creates and returns a letsencrypt authorizer
+func New(config *Config) (api.Authorize, error) {
+	if config == nil {
+		config = NewDefaultConfig()
+	}
+
+	return &authorizer{
+		config:  config,
+		resolve: &resolverImp{},
+	}, nil
+}
+
+// NewFromFile reads the configuration path and returns the authorizer
+func NewFromFile(path string) (api.Authorize, error) {
+	if path == "" {
+		return New(nil)
+	}
+	cfg := &Config{}
+	if err := utils.NewConfig(path).Read(cfg); err != nil {
+		return nil, err
+	}
+
+	return New(cfg)
+}
+
+type resolverImp struct{}
+
+func (s *resolverImp) GetCNAME(hostname string) (string, error) {
+	return net.LookupCNAME(hostname)
+}

--- a/pkg/authorize/kubecertmanager/authorize_test.go
+++ b/pkg/authorize/kubecertmanager/authorize_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2017 Home Office All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubecertmanager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	extensions "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/UKHomeOffice/policy-admission/pkg/api"
+)
+
+func TestNew(t *testing.T) {
+	c, err := New(newTestConfig())
+	assert.NotNil(t, c)
+	assert.NoError(t, err)
+}
+
+func TestNewDefaultConfig(t *testing.T) {
+	assert.NotNil(t, NewDefaultConfig())
+}
+
+func TestAuthorizer(t *testing.T) {
+	config := NewDefaultConfig()
+	config.ExternalIngressHostname = "ingress.acp.example.com"
+	config.HostedDomains = []string{"example.com"}
+
+	checks := map[string]kubeCertCheck{
+		"check that the ingress is allow through": {},
+		"check an internally hosted domain is permited": {
+			Annotations: map[string]string{"kubernetes.io/ingress.class": "nginx-external"},
+			Labels:      map[string]string{"stable.k8s.psg.io/kcm.class": "default"},
+			Hosts:       []string{"site.example.com"},
+		},
+		"check an externaly hosted domain is denied": {
+			Annotations: map[string]string{"kubernetes.io/ingress.class": "nginx-external"},
+			Labels:      map[string]string{"stable.k8s.psg.io/kcm.class": "default"},
+			Hosts:       []string{"site.nohere.com"},
+			Errors: field.ErrorList{
+				{
+					Field:    "annotations[stable.k8s.psg.io/kcm.provider]",
+					BadValue: "",
+					Type:     field.ErrorTypeInvalid,
+					Detail:   "one or more domains in the ingress are externally hosted, you must use a http challenge",
+				},
+			},
+		},
+		"check an externaly host is denied no invalid challenge": {
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class":    "nginx-external",
+				"stable.k8s.psg.io/kcm.provider": "bad",
+			},
+			Labels: map[string]string{"stable.k8s.psg.io/kcm.class": "default"},
+			Hosts:  []string{"site.nohere.com"},
+			Errors: field.ErrorList{
+				{
+					Field:    "annotations[stable.k8s.psg.io/kcm.provider]",
+					BadValue: "bad",
+					Type:     field.ErrorTypeInvalid,
+					Detail:   "invalid kube-cert-manager provider type: bad, expected: http",
+				},
+			},
+		},
+		"check an externaly host is denied when ingress is not external": {
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class":    "nginx-internal",
+				"stable.k8s.psg.io/kcm.provider": "http",
+			},
+			Labels: map[string]string{"stable.k8s.psg.io/kcm.class": "default"},
+			Hosts:  []string{"site.nohere.com"},
+			Errors: field.ErrorList{
+				{
+					Field:    "annotations[kubernetes.io/ingress.class]",
+					BadValue: "nginx-internal",
+					Type:     field.ErrorTypeInvalid,
+					Detail:   "invalid kube-cert-manager provider, expected 'nginx-external' for a http challenge",
+				},
+			},
+		},
+		"check a ingress is denied when the dns does not resolve": {
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class":    "nginx-external",
+				"stable.k8s.psg.io/kcm.provider": "http",
+			},
+			Labels:   map[string]string{"stable.k8s.psg.io/kcm.class": "default"},
+			Hosts:    []string{"site.nohere.com"},
+			Resolves: "bad.hostname",
+			Errors: field.ErrorList{
+				{
+					Field:    "spec.rules[0].host",
+					BadValue: "site.nohere.com",
+					Type:     field.ErrorTypeInvalid,
+					Detail:   "the hostname: site.nohere.com is not pointed to the external ingress dns name ingress.acp.example.com",
+				},
+			},
+		},
+		"check a ingress permitted when resolves": {
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class":    "nginx-external",
+				"stable.k8s.psg.io/kcm.provider": "http",
+			},
+			Labels:   map[string]string{"stable.k8s.psg.io/kcm.class": "default"},
+			Hosts:    []string{"site.nohere.com"},
+			Resolves: config.ExternalIngressHostname,
+		},
+	}
+	newTestAuthorizer(t, config).runChecks(t, checks)
+}
+
+type kubeCertCheck struct {
+	Annotations map[string]string
+	Errors      field.ErrorList
+	Hosts       []string
+	Labels      map[string]string
+	Resolves    string
+}
+
+type testAuthorizer struct {
+	config *Config
+	svc    api.Authorize
+}
+
+type testResolver struct {
+	hostname string
+}
+
+func (t *testResolver) GetCNAME(string) (string, error) {
+	return t.hostname, nil
+}
+
+func newTestAuthorizer(t *testing.T, config *Config) *testAuthorizer {
+	if config == nil {
+		config = newTestConfig()
+	}
+	c, err := New(config)
+	c.(*authorizer).resolve = &testResolver{}
+
+	require.NoError(t, err)
+
+	return &testAuthorizer{config: config, svc: c}
+}
+
+func (c *testAuthorizer) runChecks(t *testing.T, checks map[string]kubeCertCheck) {
+	for desc, check := range checks {
+		// update the resolver
+		if check.Resolves != "" {
+			c.svc.(*authorizer).resolve = &testResolver{hostname: check.Resolves}
+		}
+
+		ingress := newDefaultIngress()
+		for _, x := range check.Hosts {
+			ingress.Spec.Rules = append(ingress.Spec.Rules, extensions.IngressRule{Host: x})
+		}
+		ingress.ObjectMeta.Annotations = check.Annotations
+		ingress.ObjectMeta.Labels = check.Labels
+
+		client := fake.NewSimpleClientset()
+		mcache := cache.New(1*time.Minute, 1*time.Minute)
+
+		assert.Equal(t, check.Errors, c.svc.Admit(client, mcache, ingress), "case: '%s' result not as expected", desc)
+	}
+}
+
+func newDefaultIngress() *extensions.Ingress {
+	return &extensions.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-",
+			Namespace: "test",
+		},
+		Spec: extensions.IngressSpec{},
+	}
+}
+
+func newTestConfig() *Config {
+	return &Config{
+		IgnoreNamespaces: []string{"kube-system"},
+	}
+}

--- a/pkg/authorize/kubecertmanager/doc.go
+++ b/pkg/authorize/kubecertmanager/doc.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 Home Office All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubecertmanager
+
+const (
+	// Name is the name of the authorizer
+	Name = "kubecertmanager"
+	// Annotation provides a namespace specific override for image policy
+	Annotation = "policy-admission.acp.homeoffice.gov.uk/" + Name
+)
+
+// Config is the configuration for the service
+type Config struct {
+	// ExternalIngressHostname is the dns hostname which external ingresses should be pointing to
+	ExternalIngressHostname string `yaml:"external-ingress-hostname" json:"external-ingress-hostname"`
+	// IgnoredNamespaces is a list namespaces to ignore
+	IgnoreNamespaces []string `yaml:"ignored-namespaces" json:"ignored-namespaces"`
+	// HostedDomains is a list of hosted domains we can add records for
+	HostedDomains []string `yaml:"hosted-domains" json:"hosted-domains"`
+}
+
+// NewDefaultConfig returns a default config
+func NewDefaultConfig() *Config {
+	return &Config{
+		IgnoreNamespaces: []string{"kube-system", "kube-admission"},
+	}
+}


### PR DESCRIPTION
Adds more of a verification service than authorizer as it is used to vet common mistakes in the ingresses when requesting certificates