### PR TITLE
Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM alpine:3.6
+FROM alpine:3.7
 MAINTAINER Rohith Jayawardene <gambol99@gmail.com>
 
-RUN apk add ca-certificates --update
+RUN apk add ca-certificates --no-cache
 
 ADD bin/policy-admission /policy-admission
 
 RUN adduser -D controller
-USER controller
+
+USER 1000
 
 ENTRYPOINT [ "/policy-admission" ]


### PR DESCRIPTION
- updating the base to the latest alpine
- ensure we don't cache the package on install
- using a UID rather than username