### PR TITLE
Kubernetes >= 1.9

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,34 +1,16 @@
 hash: 278b4a889a21f9c84b3ca86edf2bb04a133f062b7a64812db1d0e932b1f87176
-updated: 2018-03-02T16:53:24.244720772Z
+updated: 2018-03-29T13:18:08.422084794+01:00
 imports:
 - name: github.com/beorn7/perks
-  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
-- name: github.com/davecgh/go-spew
-  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
-  subpackages:
-  - spew
 - name: github.com/dgrijalva/jwt-go
   version: 01aeca54ebda6e0fbfafd0a524d234159c05ec20
-- name: github.com/emicklei/go-restful
-  version: ff4f55a206334ef123e4f79bbf348980da81ca46
-  subpackages:
-  - log
-- name: github.com/emicklei/go-restful-swagger12
-  version: dcef7f55730566d41eae5db10e7d6981829720f6
 - name: github.com/fsnotify/fsnotify
-  version: fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197
+  version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
-- name: github.com/go-openapi/jsonpointer
-  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
-- name: github.com/go-openapi/jsonreference
-  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
-- name: github.com/go-openapi/spec
-  version: 6aced65f8501fe1217321abf0749d354824ba2ff
-- name: github.com/go-openapi/swag
-  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
+  version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -37,15 +19,13 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
   subpackages:
   - proto
   - ptypes
   - ptypes/any
   - ptypes/duration
   - ptypes/timestamp
-- name: github.com/google/btree
-  version: 7d79101e329e5a3adf994758c578dab82b90c017
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/googleapis/gnostic
@@ -54,49 +34,35 @@ imports:
   - OpenAPIv2
   - compiler
   - extensions
-- name: github.com/gregjones/httpcache
-  version: 787624de3eb7bd915c329cba748687a3b22666a6
-  subpackages:
-  - diskcache
 - name: github.com/json-iterator/go
-  version: 36b14963da70d11297d313183d7e6388c8510e1e
-- name: github.com/juju/ratelimit
-  version: 5b9ff866471762aa2ab2dced63c9fb6f53921342
+  version: 13f86432b882000a51c6e610c620974462691a97
 - name: github.com/labstack/echo
-  version: a625e589cffa33eac768ab98bc21518cef786e2d
+  version: fb30777387f27ca69c8e4b163b7448a290a5450c
   subpackages:
   - middleware
 - name: github.com/labstack/gommon
-  version: 779b8a8b9850a97acba6a3fe20feb628c39e17c1
+  version: 058e16e77bbd66cc101dfeae2971b88add6ce266
   subpackages:
   - bytes
   - color
   - log
   - random
-- name: github.com/mailru/easyjson
-  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
-  subpackages:
-  - buffer
-  - jlexer
-  - jwriter
 - name: github.com/mattn/go-colorable
-  version: ad5389df28cdac544c99bd7b9161a0b5b6ca9d1b
+  version: 7dc3415be66d7cc68bf0182f35c8d31f8d2ad8a7
 - name: github.com/mattn/go-isatty
-  version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
+  version: 6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
 - name: github.com/matttproud/golang_protobuf_extensions
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
   - pbutil
 - name: github.com/patrickmn/go-cache
   version: a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0
-- name: github.com/peterbourgon/diskv
-  version: 5f041e8faa004a95c88a202771f4cc3e991971e6
 - name: github.com/prometheus/client_golang
-  version: 488edd04dc224ba64c401747cd0a4b5f05dfb234
+  version: c3324c1198cf3374996e9d3098edd46a6b55afc9
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:
   - go
 - name: github.com/prometheus/common
@@ -106,23 +72,21 @@ imports:
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: abf152e5f3e97f2fafac028d2cc06c1feb87ffa5
-- name: github.com/PuerkitoBio/purell
-  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
-- name: github.com/PuerkitoBio/urlesc
-  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+  version: 65c1f6f8f0fc1e2185eb9863a3bc751496404259
+  subpackages:
+  - xfs
 - name: github.com/sirupsen/logrus
-  version: 89742aefa4b206dcf400792f3bd35b542998eb3b
+  version: f4ee69125072b22721efbe639bd0da9c9d19b8cc
 - name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
 - name: github.com/urfave/cli
-  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
+  version: 8e01ec4cd3e2d84ab2fe90d8210528ffbb06d8ff
 - name: github.com/valyala/bytebufferpool
   version: e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7
 - name: github.com/valyala/fasttemplate
   version: dcecefd839c4193db0d35b88ec65b4c12d360ab0
 - name: golang.org/x/crypto
-  version: 81e90905daefcd6fd217b62423c0908922eadb30
+  version: 49796115aa4b964c318aad4f3084fdb41e9aa067
   subpackages:
   - acme
   - acme/autocert
@@ -130,6 +94,7 @@ imports:
 - name: golang.org/x/net
   version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
+  - context
   - html
   - html/atom
   - http2
@@ -138,33 +103,33 @@ imports:
   - lex/httplex
   - websocket
 - name: golang.org/x/sys
-  version: 7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce
+  version: 95c6576299259db960f6c5b9b69ea52422860fce
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
   version: b19bf474d317b857955b12035d2c5acb57ce8b01
   subpackages:
-  - cases
-  - internal
-  - internal/tag
-  - language
-  - runes
   - secure/bidirule
-  - secure/precis
   - transform
   - unicode/bidi
   - unicode/norm
-  - width
+- name: golang.org/x/time
+  version: f51c12702a4d776e4c1fa9b0fabab841babae631
+  subpackages:
+  - rate
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: 670d4cfef0544295bc27a114dbac37980d83185a
 - name: k8s.io/api
-  version: cadaf100c0a3dd6b254f320d6d651df079ec8e0a
+  version: 055879e38033d1526b0fe169089a055c33fa3990
   subpackages:
   - admission/v1alpha1
+  - admission/v1beta1
   - admissionregistration/v1alpha1
+  - admissionregistration/v1beta1
+  - apps/v1
   - apps/v1beta1
   - apps/v1beta2
   - authentication/v1
@@ -178,6 +143,7 @@ imports:
   - batch/v2alpha1
   - certificates/v1beta1
   - core/v1
+  - events/v1beta1
   - extensions/v1beta1
   - networking/v1
   - policy/v1beta1
@@ -187,28 +153,24 @@ imports:
   - scheduling/v1alpha1
   - settings/v1alpha1
   - storage/v1
+  - storage/v1alpha1
   - storage/v1beta1
 - name: k8s.io/apiextensions-apiserver
-  version: a5bbfd114a9b122acd741c61d88c84812375d9e1
+  version: c0309dc58835e8fc6b11ac6eeb38741300ff85d0
   subpackages:
   - pkg/features
 - name: k8s.io/apimachinery
-  version: 3b05bbfa0a45413bfa184edbf9af617e277962fb
+  version: 210bcde8e5a7715fe776460ca1df1a3f2738725e
   subpackages:
-  - pkg/api/equality
   - pkg/api/errors
   - pkg/api/meta
   - pkg/api/resource
-  - pkg/apimachinery
-  - pkg/apimachinery/announced
-  - pkg/apimachinery/registered
   - pkg/apis/meta/internalversion
   - pkg/apis/meta/v1
   - pkg/apis/meta/v1/unstructured
-  - pkg/apis/meta/v1alpha1
+  - pkg/apis/meta/v1beta1
   - pkg/conversion
   - pkg/conversion/queryparams
-  - pkg/conversion/unstructured
   - pkg/fields
   - pkg/labels
   - pkg/runtime
@@ -222,7 +184,6 @@ imports:
   - pkg/selection
   - pkg/types
   - pkg/util/clock
-  - pkg/util/diff
   - pkg/util/errors
   - pkg/util/framer
   - pkg/util/intstr
@@ -238,12 +199,12 @@ imports:
   - pkg/watch
   - third_party/forked/golang/reflect
 - name: k8s.io/apiserver
-  version: c1e53d745d0fe45bf7d5d44697e6eface25fceca
+  version: f4a9d31325865f18b8023622a564578f079d582b
   subpackages:
   - pkg/features
   - pkg/util/feature
 - name: k8s.io/client-go
-  version: 82aa063804cf055e16e8911250f888bc216e8b61
+  version: 88e8ea169afa2918712ce2bc64fc1e2d11d72b12
   subpackages:
   - discovery
   - discovery/fake
@@ -252,6 +213,10 @@ imports:
   - kubernetes/scheme
   - kubernetes/typed/admissionregistration/v1alpha1
   - kubernetes/typed/admissionregistration/v1alpha1/fake
+  - kubernetes/typed/admissionregistration/v1beta1
+  - kubernetes/typed/admissionregistration/v1beta1/fake
+  - kubernetes/typed/apps/v1
+  - kubernetes/typed/apps/v1/fake
   - kubernetes/typed/apps/v1beta1
   - kubernetes/typed/apps/v1beta1/fake
   - kubernetes/typed/apps/v1beta2
@@ -278,6 +243,8 @@ imports:
   - kubernetes/typed/certificates/v1beta1/fake
   - kubernetes/typed/core/v1
   - kubernetes/typed/core/v1/fake
+  - kubernetes/typed/events/v1beta1
+  - kubernetes/typed/events/v1beta1/fake
   - kubernetes/typed/extensions/v1beta1
   - kubernetes/typed/extensions/v1beta1/fake
   - kubernetes/typed/networking/v1
@@ -296,9 +263,14 @@ imports:
   - kubernetes/typed/settings/v1alpha1/fake
   - kubernetes/typed/storage/v1
   - kubernetes/typed/storage/v1/fake
+  - kubernetes/typed/storage/v1alpha1
+  - kubernetes/typed/storage/v1alpha1/fake
   - kubernetes/typed/storage/v1beta1
   - kubernetes/typed/storage/v1beta1/fake
+  - pkg/apis/clientauthentication
+  - pkg/apis/clientauthentication/v1alpha1
   - pkg/version
+  - plugin/pkg/client/auth/exec
   - rest
   - rest/watch
   - testing
@@ -309,17 +281,16 @@ imports:
   - util/cert
   - util/flowcontrol
   - util/integer
-- name: k8s.io/kube-openapi
-  version: 868f2f29720b192240e18284659231b440f9cda5
-  subpackages:
-  - pkg/common
 - name: k8s.io/kubernetes
-  version: 7008b9043b8dcc5344b4d0e002bad252faffe7fe
+  version: 4685df26ddc2c0778564ed77ec974da56bd52994
   subpackages:
   - pkg/api
-  - pkg/api/helper
+  - pkg/apis/autoscaling
+  - pkg/apis/core
+  - pkg/apis/core/helper
   - pkg/apis/extensions
   - pkg/apis/networking
+  - pkg/apis/scheduling
   - pkg/features
   - pkg/kubelet/types
   - pkg/security/apparmor
@@ -332,15 +303,20 @@ imports:
   - pkg/security/podsecuritypolicy/sysctl
   - pkg/security/podsecuritypolicy/user
   - pkg/security/podsecuritypolicy/util
+  - pkg/securitycontext
   - pkg/util/file
   - pkg/util/maps
 testImports:
+- name: github.com/davecgh/go-spew
+  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
+  subpackages:
+  - spew
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: f6abca593680b2315d2075e0f5e2a9751e3f431a
+  version: d77da356e56a7428ad25149ca77381849a6a5232
   subpackages:
   - assert
   - require

--- a/kube/rbac.yml
+++ b/kube/rbac.yml
@@ -13,14 +13,14 @@ rules:
   - delete
   - update
 - apiGroups:
-  - v1
+  - "*"
   resources:
   - namespaces
   verbs:
   - get
   - list
 - apiGroups:
-  - v1
+  - "*"
   resources:
   - events
   verbs:

--- a/pkg/authorize/imagelist/authorizer.go
+++ b/pkg/authorize/imagelist/authorizer.go
@@ -34,7 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes"
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 // authorizer is used to wrap the interaction with the psp runtime

--- a/pkg/authorize/imagelist/authorizer_test.go
+++ b/pkg/authorize/imagelist/authorizer_test.go
@@ -33,7 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes/fake"
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 type imageListCheck struct {

--- a/pkg/authorize/images/authorize.go
+++ b/pkg/authorize/images/authorize.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes"
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 type authorizer struct {

--- a/pkg/authorize/images/authorize_test.go
+++ b/pkg/authorize/images/authorize_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes/fake"
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 func TestNew(t *testing.T) {

--- a/pkg/authorize/namespaces/authorizer.go
+++ b/pkg/authorize/namespaces/authorizer.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes"
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 // authorizer is used to wrap the interaction with the psp runtime

--- a/pkg/authorize/namespaces/authorizer_test.go
+++ b/pkg/authorize/namespaces/authorizer_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 func TestNew(t *testing.T) {

--- a/pkg/authorize/securitycontext/doc.go
+++ b/pkg/authorize/securitycontext/doc.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
@@ -82,16 +82,19 @@ func (c *Config) defaultPolicy(namespace string) (string, bool) {
 
 // NewDefaultConfig returns a default configuration for the authorizer
 func NewDefaultConfig() *Config {
+	var isfalse bool
 	return &Config{
 		Default:          "default",
 		IgnoreNamespaces: []string{},
 		NamespaceMapping: make(map[string]string, 0),
 		Policies: map[string]extensions.PodSecurityPolicySpec{
 			"default": {
-				AllowedCapabilities:      []core.Capability{},
-				DefaultAddCapabilities:   []core.Capability{},
-				FSGroup:                  extensions.FSGroupStrategyOptions{Rule: extensions.FSGroupStrategyRunAsAny},
-				RequiredDropCapabilities: []core.Capability{},
+				AllowedCapabilities:             []core.Capability{},
+				DefaultAllowPrivilegeEscalation: &isfalse,
+				AllowPrivilegeEscalation:        false,
+				DefaultAddCapabilities:          []core.Capability{},
+				FSGroup:                         extensions.FSGroupStrategyOptions{Rule: extensions.FSGroupStrategyRunAsAny},
+				RequiredDropCapabilities:        []core.Capability{},
 				RunAsUser: extensions.RunAsUserStrategyOptions{
 					Rule: extensions.RunAsUserStrategyMustRunAsNonRoot,
 				},
@@ -106,18 +109,20 @@ func NewDefaultConfig() *Config {
 				},
 			},
 			"privileged": {
-				AllowedCapabilities:    []core.Capability{"*"},
-				FSGroup:                extensions.FSGroupStrategyOptions{Rule: extensions.FSGroupStrategyRunAsAny},
-				HostIPC:                true,
-				HostNetwork:            true,
-				HostPID:                true,
-				HostPorts:              []extensions.HostPortRange{{Min: 1, Max: 65536}},
-				Privileged:             true,
-				ReadOnlyRootFilesystem: false,
-				RunAsUser:              extensions.RunAsUserStrategyOptions{Rule: extensions.RunAsUserStrategyRunAsAny},
-				SELinux:                extensions.SELinuxStrategyOptions{Rule: extensions.SELinuxStrategyRunAsAny},
-				SupplementalGroups:     extensions.SupplementalGroupsStrategyOptions{Rule: extensions.SupplementalGroupsStrategyRunAsAny},
-				Volumes:                []extensions.FSType{extensions.All},
+				AllowedCapabilities:             []core.Capability{"*"},
+				DefaultAllowPrivilegeEscalation: &isfalse,
+				AllowPrivilegeEscalation:        false,
+				FSGroup:                         extensions.FSGroupStrategyOptions{Rule: extensions.FSGroupStrategyRunAsAny},
+				HostIPC:                         true,
+				HostNetwork:                     true,
+				HostPID:                         true,
+				HostPorts:                       []extensions.HostPortRange{{Min: 1, Max: 65536}},
+				Privileged:                      true,
+				ReadOnlyRootFilesystem:          false,
+				RunAsUser:                       extensions.RunAsUserStrategyOptions{Rule: extensions.RunAsUserStrategyRunAsAny},
+				SELinux:                         extensions.SELinuxStrategyOptions{Rule: extensions.SELinuxStrategyRunAsAny},
+				SupplementalGroups:              extensions.SupplementalGroupsStrategyOptions{Rule: extensions.SupplementalGroupsStrategyRunAsAny},
+				Volumes:                         []extensions.FSType{extensions.All},
 			},
 		},
 	}

--- a/pkg/authorize/services/authorizer.go
+++ b/pkg/authorize/services/authorizer.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes"
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 // authorizer is used to wrap the interactions

--- a/pkg/authorize/services/authorizer_test.go
+++ b/pkg/authorize/services/authorizer_test.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes/fake"
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 type serviceCheck struct {

--- a/pkg/authorize/services/doc.go
+++ b/pkg/authorize/services/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 package services
 
 import (
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 const (

--- a/pkg/authorize/tolerations/authorizer.go
+++ b/pkg/authorize/tolerations/authorizer.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes"
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 // authorizer is responsible for validating the tolerations

--- a/pkg/authorize/tolerations/authorizer_test.go
+++ b/pkg/authorize/tolerations/authorizer_test.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes/fake"
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 type tolerationCheck struct {

--- a/pkg/authorize/tolerations/doc.go
+++ b/pkg/authorize/tolerations/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 package tolerations
 
 import (
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 const (

--- a/pkg/server/admission_test.go
+++ b/pkg/server/admission_test.go
@@ -30,14 +30,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	log "github.com/sirupsen/logrus"
-	admission "k8s.io/api/admission/v1alpha1"
+	admission "k8s.io/api/admission/v1beta1"
 	authentication "k8s.io/api/authentication/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 // request defines a fake review request
@@ -50,7 +50,7 @@ type request struct {
 
 	ExpectedCode    int
 	ExpectedContent string
-	ExpectedStatus  *admission.AdmissionReviewStatus
+	ExpectedStatus  *admission.AdmissionResponse
 }
 
 // testAdmission is a wrapper around a test admission server
@@ -109,10 +109,10 @@ func (c *testAdmission) runTests(t *testing.T, requests []request) {
 			x.URI = "/"
 			x.Review = &admission.AdmissionReview{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "admission.k8s.io/v1alpha1",
+					APIVersion: "admission.k8s.io/v1beta1",
 					Kind:       "AdmissionReview",
 				},
-				Spec: admission.AdmissionReviewSpec{
+				Request: &admission.AdmissionRequest{
 					Kind:      metav1.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"},
 					Name:      x.Pod.Name,
 					Namespace: x.Pod.Namespace,
@@ -159,7 +159,7 @@ func (c *testAdmission) runTests(t *testing.T, requests []request) {
 				t.Errorf("case %d, unable to decode responce, error: %s", i, err)
 				continue
 			}
-			assert.Equal(t, *x.ExpectedStatus, status.Status, "case %d: result not as expected", i)
+			assert.Equal(t, x.ExpectedStatus, status.Response, "case %d: result not as expected", i)
 		}
 	}
 }

--- a/pkg/server/misc_test.go
+++ b/pkg/server/misc_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	admission "k8s.io/api/admission/v1alpha1"
+	admission "k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	core "k8s.io/kubernetes/pkg/api"
+	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 func TestDenialEventCreated(t *testing.T) {
@@ -40,7 +40,7 @@ func TestDenialEventCreated(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "test"},
 				Spec:       core.PodSpec{SecurityContext: &core.PodSecurityContext{HostNetwork: true}},
 			},
-			ExpectedStatus: &admission.AdmissionReviewStatus{
+			ExpectedStatus: &admission.AdmissionResponse{
 				Result: &metav1.Status{
 					Code:    http.StatusForbidden,
 					Message: "spec.securityContext.hostNetwork=true : Host network is not allowed to be used",


### PR DESCRIPTION
Fixing up the policy-admission to work with kubernetes >= 1.9 as the API for the admission webhook has changed