### PR TITLE
ACPENG-1385: Update kubecertmanager helper.go getRoute53HostedDomains() function

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -35,14 +35,20 @@ steps:
     - pull_request
 
 - name: scan-image
-  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:v0.0.5-1
+  pull: Always
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+  resources:
+    limits:
+      cpu: 1000
+      memory: 1024Mi
   environment:
     IMAGE_NAME: policy-admission:${DRONE_COMMIT_SHA}
+    IGNORE_UNFIXED: "true"
   when:
     event:
+    - pull_request
     - push
     - tag
-    - pull_request
 
 - name: latest
   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
@@ -75,10 +81,3 @@ steps:
 services:
   - name: docker
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-
-  - name: anchore-submission-server
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:v0.0.5-1
-    commands:
-      - /run.sh server
-
-...

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ workspace:
 
 steps:
 - name: tests
-  image: golang:1.17.3
+  image: golang:1.21
   commands:
   - make test
   - make static

--- a/.drone.yml
+++ b/.drone.yml
@@ -55,7 +55,7 @@ steps:
       from_secret: docker_password
   when:
     branch:
-    - master
+    - main
     event:
     - push
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -44,6 +44,7 @@ steps:
   environment:
     IMAGE_NAME: policy-admission:${DRONE_COMMIT_SHA}
     IGNORE_UNFIXED: "true"
+    FAIL_ON_DETECTION: "false"
   when:
     event:
     - pull_request

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.19
 MAINTAINER Rohith Jayawardene <gambol99@gmail.com>
 
 RUN apk -U add ca-certificates --no-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,10 @@ RUN set -euxo pipefail ;\
   #Update System Packages
   apk update ;\
   apk upgrade ;\
+  apk add --no-cache \
+    ca-certificates ;\
   rm -rf /var/cache/apk/* ;\
+  update-ca-certificates ;\
   # Update File Perms
   chmod +x /policy-admission ;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,25 @@
 FROM alpine:3.19
-MAINTAINER ACP Platform Team
 
-RUN apk -U add ca-certificates --no-cache
+# Non-Root Application User
+ARG USER=application
+ARG UID=1000
 
 COPY bin/policy-admission /policy-admission
 
-USER 1000
+RUN set -euxo pipefail ;\
+  # Create non-Root user
+  adduser \
+  -D \
+  -g "" \
+  -u "$UID" \
+  -H \
+  "$USER" ; \
+  #Update System Packages
+  apk update ;\
+  apk upgrade ;\
+  rm -rf /var/cache/apk/* ;\
+  # Update File Perms
+  chmod +x /policy-admission ;
 
-ENTRYPOINT [ "/policy-admission" ]
+USER $UID
+ENTRYPOINT ["/policy-admission"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.19
-MAINTAINER Rohith Jayawardene <gambol99@gmail.com>
+MAINTAINER ACP Platform Team
 
 RUN apk -U add ca-certificates --no-cache
 

--- a/pkg/authorize/kubecertmanager/helpers.go
+++ b/pkg/authorize/kubecertmanager/helpers.go
@@ -42,17 +42,29 @@ func isHosted(ingress *networkingv1.Ingress, domains []string) bool {
 
 // getRoute53HostedDomains returns a list of hosted domains or an error
 func getRoute53HostedDomains(client route53iface.Route53API) ([]string, error) {
-	resp, err := client.ListHostedZones(&route53.ListHostedZonesInput{})
-	if err != nil {
-		return []string{}, err
-	}
-
-	var list []string
-	for _, x := range resp.HostedZones {
-		list = append(list, strings.TrimSuffix(aws.StringValue(x.Name), "."))
-	}
-
-	return list, nil
+    var hostedZones []string
+    var marker *string
+    for {
+        input := &route53.ListHostedZonesInput{
+            MaxItems: aws.String("100"),
+        }
+        if marker != nil {
+            input.Marker = marker
+        }
+        output, err := client.ListHostedZones(input)
+        if err != nil {
+            return []string{}, err
+        }
+        for _, x := range output.HostedZones {
+            hostedZones = append(hostedZones, strings.TrimSuffix(aws.StringValue(x.Name), "."))
+        }
+        if output.IsTruncated != nil && *output.IsTruncated {
+            marker = output.NextMarker
+        } else {
+            break
+        }
+    }
+    return hostedZones, nil
 }
 
 // isIngressPointed is responisble for checking the dns hostname is pointed to the external ingress


### PR DESCRIPTION
getRoute53HostedDomains() has been updated to retrieve all hosted zone above the 100 api limit (pagination-ish)